### PR TITLE
Fixing last bits writing & usage example in docks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,23 @@ BMP Tools
 Various BMP released tools for working with BMP data.  These tools are intended for 
 testing/validating BMP. 
 
+## Bmp play using example:
+1. Downloading script:
+```
+wget https://raw.githubusercontent.com/OpenBMP/dev_tools/master/bmp_play/bmp_play.py
+```
+
+2. Making BMP dump from router:
+```
+python bmp_play.py -m record -p 5000 -f router_bmp.dump
+```
+
+3. Playing dump to collector:
+```
+python bmp_play.py -m play -p 5000 -f router_bmp.dump -d 127.0.0.1
+```
+
+4. Figuring out arguments:
+```
+python bmp_play.py -h
+```

--- a/bmp_play/bmp_play.py
+++ b/bmp_play/bmp_play.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-  Copyright (c) 2015 Cisco Systems, Inc. and others.  All rights reserved.
+  Copyright (c) 2015-2016 Cisco Systems, Inc. and others.  All rights reserved.
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v1.0 which accompanies this distribution,
@@ -37,13 +37,24 @@ def record(cfg):
                 conn.close()
                 continue
 
-            with open(cfg['file'], "wb") as f:
+            f = open(cfg['file'], "wb")
+            
+            try:
                 while True:
                     data = conn.recv(1024)
+                    
                     if (not data):
+                        f.close()
                         break
 
                     f.write(data)
+                    
+            except KeyboardInterrupt as e:
+                print("Writing to file")
+                
+            finally: 
+                f.close()
+                break
 
             print " ...Done"
 


### PR DESCRIPTION
bmp_play.py used:
```
with open(cfg['file'], "wb") as f:
```
statement and python supposed to close file automatically but in case of KeyboardException it leaves file opened and last 1024 bytes can be lost. 